### PR TITLE
Don't initialize broadcast client confirmation channel by default

### DIFF
--- a/packages/arb-node-core/cmd/arb-relay/arb-relay.go
+++ b/packages/arb-node-core/cmd/arb-relay/arb-relay.go
@@ -33,6 +33,7 @@ import (
 	"github.com/offchainlabs/arbitrum/packages/arb-node-core/cmdhelp"
 	"github.com/offchainlabs/arbitrum/packages/arb-util/broadcastclient"
 	"github.com/offchainlabs/arbitrum/packages/arb-util/broadcaster"
+	"github.com/offchainlabs/arbitrum/packages/arb-util/common"
 )
 
 var logger zerolog.Logger
@@ -127,10 +128,12 @@ func startup() error {
 }
 
 func NewArbRelay(sequencerFeedAddress string, rebroadcastSettings broadcaster.Settings) *ArbRelay {
+	broadcastClient := broadcastclient.NewBroadcastClient(sequencerFeedAddress, nil)
+	broadcastClient.ConfirmedAccumulatorListener = make(chan common.Hash, 1)
 	return &ArbRelay{
 		SequencerFeedAddress: sequencerFeedAddress,
 		broadcaster:          broadcaster.NewBroadcaster(rebroadcastSettings),
-		broadcastClient:      broadcastclient.NewBroadcastClient(sequencerFeedAddress, nil),
+		broadcastClient:      broadcastClient,
 	}
 }
 

--- a/packages/arb-node-core/cmd/arb-relay/arb-relay_test.go
+++ b/packages/arb-node-core/cmd/arb-relay/arb-relay_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/offchainlabs/arbitrum/packages/arb-util/broadcastclient"
 	"github.com/offchainlabs/arbitrum/packages/arb-util/broadcaster"
+	"github.com/offchainlabs/arbitrum/packages/arb-util/common"
 )
 
 func TestRelayRebroadcasts(t *testing.T) {
@@ -81,6 +82,7 @@ func TestRelayRebroadcasts(t *testing.T) {
 
 func makeRelayClient(t *testing.T, expectedCount int, wg *sync.WaitGroup) {
 	broadcastClient := broadcastclient.NewBroadcastClient("ws://127.0.0.1:7429/", nil)
+	broadcastClient.ConfirmedAccumulatorListener = make(chan common.Hash, 1)
 	defer wg.Done()
 	messageCount := 0
 

--- a/packages/arb-util/broadcastclient/broadcastclient.go
+++ b/packages/arb-util/broadcastclient/broadcastclient.go
@@ -59,7 +59,6 @@ func NewBroadcastClient(websocketUrl string, lastInboxSeqNum *big.Int) *Broadcas
 		startingBroadcastClientMutex: &sync.Mutex{},
 		websocketUrl:                 websocketUrl,
 		lastInboxSeqNum:              seqNum,
-		ConfirmedAccumulatorListener: make(chan common.Hash),
 	}
 }
 


### PR DESCRIPTION
This was causing stalls for non-relay clients as the channel wasn't being read from.