### PR TITLE
Fix MachineThread::nextAssertion when running synchronously

### DIFF
--- a/packages/arb-avm-cpp/avm/src/machinethread.cpp
+++ b/packages/arb-avm-cpp/avm/src/machinethread.cpp
@@ -80,8 +80,10 @@ Assertion MachineThread::nextAssertion() {
     if (machine_status != MACHINE_SUCCESS) {
         return {};
     }
-    machine_thread->join();
-    machine_thread = nullptr;
+    if (machine_thread != nullptr) {
+        machine_thread->join();
+        machine_thread = nullptr;
+    }
     machine_status = MACHINE_NONE;
     return std::move(last_assertion);
 }


### PR DESCRIPTION
If running the machine synchronously, `machine_thread` is null, and therefore shouldn't be joined.