### PR TITLE
Revert "Use a fresh ValueCache for logs to avoid lazy loading issues"

### DIFF
--- a/packages/arb-avm-cpp/cavm/carbcore.cpp
+++ b/packages/arb-avm-cpp/cavm/carbcore.cpp
@@ -114,7 +114,7 @@ ByteSliceArrayResult arbCoreGetLogs(CArbCore* arbcore_ptr,
                                     const void* start_index_ptr,
                                     const void* count_ptr) {
     try {
-        ValueCache cache{1, 0};
+        ValueCache cache{0, 0};
         auto logs = static_cast<ArbCore*>(arbcore_ptr)
                         ->getLogs(receiveUint256(start_index_ptr),
                                   receiveUint256(count_ptr), cache);

--- a/packages/arb-avm-cpp/data_storage/src/arbcore.cpp
+++ b/packages/arb-avm-cpp/data_storage/src/arbcore.cpp
@@ -1749,10 +1749,9 @@ void ArbCore::operator()() {
             }
 
             for (size_t i = 0; i < logs_cursors.size(); i++) {
-                ValueCache logs_cache{1, 0};
                 if (logs_cursors[i].status == DataCursor::REQUESTED) {
                     ReadTransaction tx(data_storage);
-                    handleLogsCursorRequested(tx, i, logs_cache);
+                    handleLogsCursorRequested(tx, i, cache);
                 }
             }
 


### PR DESCRIPTION
Reverts OffchainLabs/arbitrum#2033

This doesn't seem to have solved the issue and #2063 resolves it properly